### PR TITLE
Add minimal LM Studio translation extension

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,69 @@
+function createButton(x, y) {
+  let btn = document.getElementById('lmst-translate-btn');
+  if (!btn) {
+    btn = document.createElement('button');
+    btn.id = 'lmst-translate-btn';
+    btn.textContent = '\u7ffb\u8a33';
+    btn.style.position = 'absolute';
+    btn.style.zIndex = 2147483647;
+    document.body.appendChild(btn);
+    btn.addEventListener('click', async () => {
+      const text = window.getSelection().toString();
+      removeButton();
+      const res = await chrome.runtime.sendMessage({ type: 'TRANSLATE', text });
+      showPopup(x, y, res.ok ? res.text : `Error: ${res.error}`);
+    });
+  }
+  btn.style.left = `${window.scrollX + x}px`;
+  btn.style.top = `${window.scrollY + y}px`;
+}
+
+function removeButton() {
+  const btn = document.getElementById('lmst-translate-btn');
+  if (btn) btn.remove();
+}
+
+function showPopup(x, y, text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  div.style.position = 'absolute';
+  div.style.background = 'white';
+  div.style.border = '1px solid #ccc';
+  div.style.padding = '4px';
+  div.style.zIndex = 2147483647;
+  div.style.left = `${window.scrollX + x}px`;
+  div.style.top = `${window.scrollY + y + 20}px`;
+  document.body.appendChild(div);
+  setTimeout(() => div.remove(), 5000);
+}
+
+document.addEventListener('mouseup', () => {
+  const sel = window.getSelection();
+  if (!sel || sel.isCollapsed) {
+    removeButton();
+    return;
+  }
+  const rect = sel.getRangeAt(0).getBoundingClientRect();
+  createButton(rect.right, rect.bottom);
+});
+
+async function translateAll() {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  while (nodes.length < 200 && walker.nextNode()) {
+    const node = walker.currentNode;
+    if (node.nodeValue.trim()) nodes.push(node);
+  }
+  for (const node of nodes) {
+    const res = await chrome.runtime.sendMessage({ type: 'TRANSLATE', text: node.nodeValue });
+    if (res.ok) {
+      node.nodeValue = res.text;
+    }
+  }
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'START_PAGE_TRANSLATION') {
+    translateAll();
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "LM Studio Translator (minimal)",
+  "version": "0.1.0",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "host_permissions": ["http://127.0.0.1:1234/", "http://localhost:1234/"],
+  "background": {
+    "service_worker": "sw.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Translate",
+    "default_popup": "popup.html"
+  },
+  "options_page": "options.html",
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+</head>
+<body>
+  <label>Base URL: <input id="baseUrl"></label><br>
+  <label>Model: <input id="model"></label><br>
+  <label>Target Lang: <input id="target"></label><br>
+  <button id="save">Save</button>
+  <div id="status"></div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,27 @@
+const baseUrlEl = document.getElementById('baseUrl');
+const modelEl = document.getElementById('model');
+const targetEl = document.getElementById('target');
+const statusEl = document.getElementById('status');
+
+const DEFAULTS = {
+  baseUrl: 'http://127.0.0.1:1234/v1',
+  model: '',
+  target: 'ja'
+};
+
+chrome.storage.sync.get(DEFAULTS, items => {
+  baseUrlEl.value = items.baseUrl;
+  modelEl.value = items.model;
+  targetEl.value = items.target;
+});
+
+document.getElementById('save').addEventListener('click', () => {
+  chrome.storage.sync.set({
+    baseUrl: baseUrlEl.value,
+    model: modelEl.value,
+    target: targetEl.value
+  }, () => {
+    statusEl.textContent = 'Saved';
+    setTimeout(() => (statusEl.textContent = ''), 1000);
+  });
+});

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+</head>
+<body>
+  <button id="translate-page">このページを全文翻訳して置換</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,4 @@
+document.getElementById('translate-page').addEventListener('click', async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  chrome.tabs.sendMessage(tab.id, { type: 'START_PAGE_TRANSLATION' });
+});

--- a/extension/sw.js
+++ b/extension/sw.js
@@ -1,0 +1,46 @@
+const DEFAULTS = {
+  baseUrl: 'http://127.0.0.1:1234/v1',
+  model: '',
+  target: 'ja'
+};
+
+async function getSettings() {
+  return new Promise(resolve => {
+    chrome.storage.sync.get(DEFAULTS, resolve);
+  });
+}
+
+async function translate(text) {
+  const { baseUrl, model, target } = await getSettings();
+  const res = await fetch(`${baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model,
+      messages: [
+        { role: 'system', content: `Translate to ${target}. Preserve formatting. No explanations.` },
+        { role: 'user', content: text }
+      ],
+      temperature: 0.2
+    })
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content || '';
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  (async () => {
+    try {
+      if (message.type === 'TRANSLATE') {
+        const text = await translate(message.text);
+        sendResponse({ ok: true, text });
+      }
+    } catch (err) {
+      sendResponse({ ok: false, error: err.message });
+    }
+  })();
+  return true;
+});


### PR DESCRIPTION
## Summary
- scaffold MV3 extension with service worker, content script and popup
- implement LM Studio API translator and selection popup
- add options page and page-wide translation support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b54f7c9c2c832e99efadbbb684a391