### PR TITLE
docs: mention CORS toggle and limit base URL to http

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+The working extension lives in `extension/`. Key modules: `manifest.json` defines MV3 permissions and entry points; `content.js` renders the in-page translate button and handles selection/DOM replacement; `sw.js` is the service worker that proxies translation requests to LM Studio; `popup.js` and `popup.html` trigger full-page translation; `options.js` and `options.html` persist API settings with `chrome.storage.sync`; shared defaults are in `constants.js`. Icons reside in `extension/icons/`.
+
+## Build, Test, and Development Commands
+This project is browser-run; no bundler is required. For local development, load the unpacked extension via Chrome → `chrome://extensions` → Enable Developer Mode → “Load unpacked” → select the `extension/` directory. When distributing a build, run `zip -r lmstudio-translator.zip extension` from the repository root and upload the archive.
+
+## Coding Style & Naming Conventions
+JavaScript files use ES modules with two-space indentation and single quotes only when interpolation is not needed. Prefer `const`/`let` over `var`, arrow functions for inline handlers, and descriptive camelCase identifiers (e.g., `translateWholePage`). Keep DOM IDs and classes kebab-cased, matching `content.js` conventions. Document complex logic with concise inline comments.
+
+## Testing Guidelines
+Automated tests are not yet defined; validate changes manually. Steps: (1) reload the extension in `chrome://extensions`; (2) on a test page, select text and confirm the floating “翻訳” button displays translated output; (3) verify the popup’s “全文翻訳” control replaces page text; (4) adjust options and ensure values persist after a browser restart. Note any regressions in the pull request.
+
+## Commit & Pull Request Guidelines
+Follow the existing history by starting commit subjects with a lowercase scope prefix when applicable (e.g., `docs:`, `fix:`) followed by a concise summary under 60 characters. Use the body to explain motivation and testing. Pull requests should include: purpose summary, before/after notes for UI-affecting changes, manual test evidence, and references to related issues.
+
+## Security & Configuration Tips
+Limit API hosts to `http://127.0.0.1` or `http://localhost` as declared in `manifest.json`, and ensure LM Studio runs with CORS enabled. Avoid storing secrets—`chrome.storage.sync` is for non-sensitive defaults only. Review additions for new network requests and update host permissions deliberately.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ LM Studio のローカル API（OpenAI 互換）を呼び出して、選択テ�
 - 設定同期: 翻訳方向（英→日 / 日→英）、自動翻訳、原文ホバー表示、選択ボタン表示などを `chrome.storage.sync` に保存。
 
 ## 前提条件
-- LM Studio の Local Server（OpenAI Compatibility API）を `http://127.0.0.1:1234/v1` などで起動し、**CORS を有効化**していること。
+- LM Studio の Local Server（OpenAI Compatibility API）を `http://localhost:1234/v1`（または `http://127.0.0.1:1234/v1`）で起動し、**CORS を有効化**していること。
   - CLI 例: `lms server start --cors --port 1234`
   - ドキュメント: [LM Studio Docs – OpenAI Compatibility API](https://lmstudio.ai/docs/local-server/openai-compatibility-api)
 - Google Chrome（Manifest V3 対応版）。
@@ -17,11 +17,11 @@ LM Studio のローカル API（OpenAI 互換）を呼び出して、選択テ�
 ## 構成とデータフロー
 1. `content.js` が選択テキストやページ DOM テキストノードを取得。
 2. `chrome.runtime.sendMessage` で Service Worker (`sw.js`) に翻訳要求 (`TRANSLATE`) やモデル一覧要求 (`LIST_MODELS`) を送信。
-3. `sw.js` が `fetch` で LM Studio の `/v1/chat/completions` または `/v1/models` にアクセスし、結果を返却。
+3. `sw.js` が `fetch` で LM Studio の `/v1/chat/completions` または `/v1/models`（フォールバックで `/models`）にアクセスし、結果を返却。
 4. `content.js` が結果をポップ表示、またはページノードのテキストを置換。
 
 ## インストール手順
-1. LM Studio を起動し、左下の **Developer > Local Server** から API サーバーを開始（必要に応じてポートを確認）。
+1. LM Studio を起動し、左下の **Developer > Local Server** から API サーバーを開始（デフォルトはポート `1234`。必要に応じて変更を確認）。
 2. このリポジトリを取得して `extension/` ディレクトリを保持。
 3. Chrome で `chrome://extensions` を開き、右上の「デベロッパーモード」をオン。
 4. 「パッケージ化されていない拡張機能を読み込む」→ リポジトリ内の `extension/` を選択。
@@ -68,7 +68,7 @@ Content-Type: application/json
 }
 ```
 
-- モデル一覧取得は `GET http://127.0.0.1:1234/v1/models` を使用（フォールバックで `/api/v0/models` を試行）。
+- モデル一覧取得は `GET http://127.0.0.1:1234/v1/models` を利用（必要に応じて `/models` や `/api/v0/models` をフォールバックで試行）。
 - 応答は OpenAI 形式で、`choices[0].message.content` を翻訳結果として利用します。
 
 ## 主要ファイル

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Target Lang: ja など
 host_permissions:
 http://127.0.0.1/*
 http://localhost/*
-permissions: storage, activeTab, scripting
+permissions: storage, activeTab, scripting, contextMenus
 設定保存は chrome.storage.sync（モデル名・Base URL・Target）。同期上限は約100KB
 5. LM Studio API（OpenAI互換）
 
@@ -70,7 +70,8 @@ manifest.json（抜粋）
   "permissions": [
     "storage",
     "activeTab",
-    "scripting"
+    "scripting",
+    "contextMenus"
   ],
   "host_permissions": [
     "http://127.0.0.1/*",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 LM Studio互換APIのみを叩く最小Chrome拡張。
 要件:
 
-LM StudioのAPI設定で作動
+LM StudioのAPI設定で作動（Chrome拡張からアクセスする場合は CORS を有効化しておく）
 選択テキスト時に選択近傍へ拡張アイコンを出し、クリックで翻訳→結果を近傍ポップ表示
 右上の拡張ポップから「全文翻訳」開始。終了後ページ上テキストを置換
 1. 構成
@@ -15,7 +15,7 @@ content.js → chrome.runtime.sendMessage → sw.js → fetch( LM Studio /v1/cha
 全文はcontent.jsがDOMテキストノードを列挙→逐次翻訳→置換
 2. インストール
 
-LM StudioでローカルAPIサーバを起動（Developer/Local Server）
+LM StudioでローカルAPIサーバを起動（Developer/Local Server）し、CORS を ON にする（CLI: `lms server start --cors --port 1234` など）
 このリポジトリを取得
 Chrome → chrome://extensions → デベロッパーモード → パッケージ化されていない拡張機能を読み込む → /extensionを選択
 拡張の「詳細」→「拡張機能のオプション」から以下を設定
@@ -37,8 +37,8 @@ Target Lang: ja など
 4. 設定・権限
 
 host_permissions:
-http://127.0.0.1:1234/*
-http://localhost:1234/*
+http://127.0.0.1/*
+http://localhost/*
 permissions: storage, activeTab, scripting
 設定保存は chrome.storage.sync（モデル名・Base URL・Target）。同期上限は約100KB
 5. LM Studio API（OpenAI互換）
@@ -66,15 +66,15 @@ manifest.json（抜粋）
 {
   "manifest_version": 3,
   "name": "LM Studio Translator (minimal)",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "permissions": [
     "storage",
     "activeTab",
     "scripting"
   ],
   "host_permissions": [
-    "http://127.0.0.1:1234/",
-    "http://localhost:1234/"
+    "http://127.0.0.1/*",
+    "http://localhost/*"
   ],
   "background": {
     "service_worker": "sw.js",

--- a/README.md
+++ b/README.md
@@ -1,115 +1,89 @@
 # LM Studio Translator (MV3, minimal)
 
-LM Studio互換APIのみを叩く最小Chrome拡張。
-要件:
+LM Studio のローカル API（OpenAI 互換）を呼び出して、選択テキストやページ全文を最小構成で翻訳する Chrome 拡張です。ローカル環境のみを対象とし、CORS を有効化した LM Studio に接続して動作します。
 
-LM StudioのAPI設定で作動（Chrome拡張からアクセスする場合は CORS を有効化しておく）
-選択テキスト時に選択近傍へ拡張アイコンを出し、クリックで翻訳→結果を近傍ポップ表示
-右上の拡張ポップから「全文翻訳」開始。終了後ページ上テキストを置換
-1. 構成
+## 主な機能
+- 選択テキスト翻訳: テキストをドラッグで選び、近傍に表示される「翻訳」ボタンで即時翻訳。
+- ページ全文翻訳: ポップアップのボタン、またはページのコンテキストメニュー「このページを翻訳」から一括処理。
+- モデル切り替え: LM Studio の `/models` エンドポイントからロード済みモデル一覧を取得し、ポップアップで選択。
+- 設定同期: 翻訳方向（英→日 / 日→英）、自動翻訳、原文ホバー表示、選択ボタン表示などを `chrome.storage.sync` に保存。
 
+## 前提条件
+- LM Studio の Local Server（OpenAI Compatibility API）を `http://127.0.0.1:1234/v1` などで起動し、**CORS を有効化**していること。
+  - CLI 例: `lms server start --cors --port 1234`
+  - ドキュメント: [LM Studio Docs – OpenAI Compatibility API](https://lmstudio.ai/docs/local-server/openai-compatibility-api)
+- Google Chrome（Manifest V3 対応版）。
 
-データフロー
+## 構成とデータフロー
+1. `content.js` が選択テキストやページ DOM テキストノードを取得。
+2. `chrome.runtime.sendMessage` で Service Worker (`sw.js`) に翻訳要求 (`TRANSLATE`) やモデル一覧要求 (`LIST_MODELS`) を送信。
+3. `sw.js` が `fetch` で LM Studio の `/v1/chat/completions` または `/v1/models` にアクセスし、結果を返却。
+4. `content.js` が結果をポップ表示、またはページノードのテキストを置換。
 
-content.js → chrome.runtime.sendMessage → sw.js → fetch( LM Studio /v1/chat/completions ) → 応答返却
-全文はcontent.jsがDOMテキストノードを列挙→逐次翻訳→置換
-2. インストール
+## インストール手順
+1. LM Studio を起動し、左下の **Developer > Local Server** から API サーバーを開始（必要に応じてポートを確認）。
+2. このリポジトリを取得して `extension/` ディレクトリを保持。
+3. Chrome で `chrome://extensions` を開き、右上の「デベロッパーモード」をオン。
+4. 「パッケージ化されていない拡張機能を読み込む」→ リポジトリ内の `extension/` を選択。
+5. 拡張の「詳細」→「拡張機能のオプション」で Base URL、モデル、翻訳方向などを設定。
 
-LM StudioでローカルAPIサーバを起動（Developer/Local Server）し、CORS を ON にする（CLI: `lms server start --cors --port 1234` など）
-このリポジトリを取得
-Chrome → chrome://extensions → デベロッパーモード → パッケージ化されていない拡張機能を読み込む → /extensionを選択
-拡張の「詳細」→「拡張機能のオプション」から以下を設定
-Base URL: http://127.0.0.1:1234/v1
-Model: 例 qwen2.5-7b-instruct（LM Studioでロードしたモデル名）
-Target Lang: ja など
-3. 使い方
+## 使い方
+### 選択テキストを翻訳
+1. ページ上でテキストを選択。
+2. 近傍に表示される「翻訳」ボタンをクリック。
+3. ボタン付近にポップアップで翻訳結果が表示され、クリックで閉じられます。
 
-選択翻訳（近傍ポップ）
+### ページ全文を翻訳
+- 拡張ポップアップで「このページを全文翻訳して置換」を押す。
+- または、ページ上で右クリック→「このページを翻訳」を選択（コンテキストメニュー）。
+- 進捗オーバーレイに処理件数が表示され、キャンセルボタンで中断できます。
 
-ページ上でテキストを選択
-選択近くに小ボタン「翻訳」が出る
-ボタンを押す → 近傍に結果ポップが表示
-全文翻訳（置換）
+### ポップアップで設定できる項目
+- 翻訳方向 (`enja` / `jaen`)
+- 自動全文翻訳（ページロード時に実行）
+- 原文ホバー表示（翻訳結果の `title` 属性に原文を残す）
+- 選択ボタンの表示有無
+- モデル選択（一覧の再取得や保存済みモデルの保持）
 
-ブラウザ右上の拡張アイコンを開く
-「このページを全文翻訳して置換」を押す
-完了後、ページ内のテキストノードが翻訳結果で置換
-4. 設定・権限
+## 設定と権限
+- `chrome.storage.sync` に Base URL / モデル名 / 翻訳方向 / UI 設定を保存（同期上限は約 100 KB）。
+- `manifest.json` の主な権限:
+  - `permissions`: `storage`, `activeTab`, `scripting`, `contextMenus`
+  - `host_permissions`: `http://127.0.0.1/*`, `http://localhost/*`
+- 背景スクリプトは MV3 Service Worker (`sw.js`) として動作し、ネットワークアクセスやコンテキストメニュー登録を担当します。
 
-host_permissions:
-http://127.0.0.1/*
-http://localhost/*
-permissions: storage, activeTab, scripting, contextMenus
-設定保存は chrome.storage.sync（モデル名・Base URL・Target）。同期上限は約100KB
-5. LM Studio API（OpenAI互換）
+## LM Studio API 呼び出し例
+```http
+POST http://127.0.0.1:1234/v1/chat/completions
+Content-Type: application/json
 
-エンドポイント: POST {BASE}/chat/completions
-例ボディ:
 {
-  "model": "qwen2.5-7b-instruct",
+  "model": "google/gemma-3-1b",
   "messages": [
-    { "role": "system", "content": "Translate to ja. Preserve formatting. No explanations." },
-    { "role": "user", "content": "source text..." }
+    { "role": "system", "content": "Translate the user's text into ja. Preserve formatting." },
+    { "role": "user", "content": "source text" }
   ],
-  "temperature": 0.2
+  "temperature": 0.2,
+  "stream": false
 }
+```
 
-  •	応答: OpenAI形式。choices[0].message.contentを取り出して使用
-  •	LM StudioのローカルAPIは通常APIキー不要
+- モデル一覧取得は `GET http://127.0.0.1:1234/v1/models` を使用（フォールバックで `/api/v0/models` を試行）。
+- 応答は OpenAI 形式で、`choices[0].message.content` を翻訳結果として利用します。
 
-⸻
+## 主要ファイル
+- `extension/manifest.json`: MV3 用 manifest。バージョン `0.1.1`、コンテキストメニュー許可などを定義。
+- `extension/sw.js`: 翻訳・モデル一覧リクエストの仲介、エラーハンドリング、コンテキストメニュー登録。
+- `extension/content.js`: 選択テキスト UI、全文翻訳ロジック、進捗表示。
+- `extension/popup.{html,js}`: 設定 UI とメッセージ送信、モデル一覧の更新。
+- `extension/options.{html,js}`: Base URL / モデル / 翻訳方向などの保存。
+- `extension/constants.js`: デフォルトの Base URL・モデル・翻訳方向・最大処理ノード数を定義。
 
-主要ファイル
-manifest.json（抜粋）
+## トラブルシュート
+- 応答が返らない: LM Studio の Local Server が起動しているか、Base URL に `/v1` が含まれているか確認。
+- モデル一覧が空: LM Studio でモデルがロード済みか確認し、ポップアップの「再取得」で `/models` エンドポイントへの接続を再試行。
+- 全文翻訳が途中で止まる: 進捗オーバーレイのキャンセルを誤って押していないか確認し、`options` で `maxNodes` を調整。
+- CORS や権限エラー: LM Studio 側で CORS が有効化されているか、拡張の `host_permissions` に対象ホストが含まれているか確認。
 
-```json
-{
-  "manifest_version": 3,
-  "name": "LM Studio Translator (minimal)",
-  "version": "0.1.1",
-  "permissions": [
-    "storage",
-    "activeTab",
-    "scripting",
-    "contextMenus"
-  ],
-  "host_permissions": [
-    "http://127.0.0.1/*",
-    "http://localhost/*"
-  ],
-  "background": {
-    "service_worker": "sw.js",
-    "type": "module"
-  },
-  "action": {
-    "default_title": "Translate",
-    "default_popup": "popup.html"
-  },
-  "options_page": "options.html",
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["content.js"],
-      "run_at": "document_idle"
-    }
-  ]
-}
-
-sw.js（役割） • 受信: { type: "TRANSLATE", text } • 送信: { ok: true, text } or { ok: false, error } • fetchでLM Studioの/v1/chat/completionsへPOST
-
-content.js（役割） • mouseupで選択文字列を取得 • 近傍に「翻訳」ボタンを描画→クリック時にSWへメッセージ • 結果を近傍ポップに描画 • START_PAGE_TRANSLATION受信でページ全文を逐次翻訳して置換 • 過負荷防止のため最大処理ノード数を制限（必要に応じ調整）
-
-popup.html / popup.js • ボタン押下でtabs.sendMessage→START_PAGE_TRANSLATION
-
-options.html / options.js • Base URL / Model / Targetをstorage.syncに保存・読込
-
-⸻
-
-開発メモ • MV3は永続BGではなくService Worker。状態はストレージ側で管理 • クロスオリジンfetchはSW側で実行。host_permissionsで許可しておく • コンテントスクリプトはDOM操作とSWメッセージングに専念 • 同期ストレージは軽設定向け。大量データはstorage.localやIndexedDBへ
-⸻
-
-トラブルシュート • 応答が空: モデル未指定、サーバ未起動、Base URL誤りを確認 • CORS/権限エラー: host_permissionsとSW側でのfetch実行を確認 • 全文翻訳で欠落: 非表示要素や除外タグ（SCRIPT等）は対象外。上限数も確認
-⸻
-
-ライセンス • 任意（テンプレート）。Plamo等の商標やトレードドレスの模倣は回避
-出典:
+## ライセンス
+- ライセンスは `LICENSE` を参照してください。ブランドやロゴの無断使用は避けてください。

--- a/extension/options.js
+++ b/extension/options.js
@@ -57,8 +57,8 @@ function validateInputs() {
   } else {
     try {
       const parsed = new URL(baseUrl);
-      if (!/^https?:$/.test(parsed.protocol)) {
-        throw new Error("Base URL must use HTTP or HTTPS.");
+      if (parsed.protocol !== "http:") {
+        throw new Error("Base URL must use http:// for LM Studio's local server.");
       }
     } catch (err) {
       fieldErrors.baseUrl = err?.message || "Invalid Base URL.";


### PR DESCRIPTION
## Summary
- note in the README that CORS must be enabled when launching LM Studio’s local server for the Chrome extension
- update the documented host permissions to mirror the manifest and bump the version shown in the snippet
- require http:// Base URLs in the options page so validation stays consistent with MV3 host permissions

## Testing
- not run (docs/validation-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds AGENTS.md, updates README with CORS/local API details and endpoints, and changes options validation to require http:// Base URLs.
> 
> - **Docs**
>   - **`AGENTS.md`**: Add repository guidelines (structure, dev workflow, style, testing, PR/commit, security tips).
>   - **`README.md`**: Note CORS requirement, clarify local API base (`/v1`), detail model list endpoint with fallbacks, update permissions/version references, and minor wording tweaks.
> - **Options**
>   - **`extension/options.js`**: Tighten validation to require `http://` (no HTTPS) for `baseUrl` with updated error message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c36e0f4440775137aa5a842923f8e94c768d7f18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->